### PR TITLE
Add interface to initiate an planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ bundle install
  
 ## Usage
 
-TODO: Write usage instructions here
+### Start planning
+
+```sh
+bin/planner plan --type day --editor
+```
 
 ## License
 

--- a/exe/planner
+++ b/exe/planner
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+# resolve bin path, ignoring symlinks
+require "pathname"
+bin_file = Pathname.new(__FILE__).realpath
+
+# add self to libpath
+$:.unshift File.expand_path("../../lib", bin_file)
+
+# Fixes https://github.com/rubygems/rubygems/issues/1420
+require "rubygems/specification"
+
+class Gem::Specification
+  def this; self; end
+end
+
+# start up the CLI
+require "bundler/setup"
+require "gplanner"
+
+Gplanner.run(ARGV)

--- a/gplanner.gemspec
+++ b/gplanner.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "thor", "~> 0.19.4"
+
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/gplanner.rb
+++ b/lib/gplanner.rb
@@ -1,5 +1,15 @@
+require "thor"
 require "gplanner/version"
+require "gplanner/planner"
+require "gplanner/command"
+
 
 module Gplanner
-  # Your code goes here...
+  def self.run(arguments)
+    Gplanner::Command.start(arguments)
+  end
+
+  def self.command_line(command)
+    system(command)
+  end
 end

--- a/lib/gplanner/command.rb
+++ b/lib/gplanner/command.rb
@@ -1,0 +1,23 @@
+module Gplanner
+  class Command < Thor
+    desc "plan", "Plan your day, week and month"
+    option :type, aliases: "-t", required: true, desc: "Type for the plan"
+    option :editor, type: :boolean, aliases: "-e", desc: "Open file in Vim"
+
+    def plan
+      meta = Planner.meta_for(options[:type])
+      execute_command "git checkout -b #{meta.branch}"
+      execute_command "touch #{meta.filename}"
+
+      if options[:editor]
+        execute_command "vim #{meta.filename}"
+      end
+    end
+
+    private
+
+    def execute_command(command)
+      Gplanner.command_line(command)
+    end
+  end
+end

--- a/lib/gplanner/planner.rb
+++ b/lib/gplanner/planner.rb
@@ -1,0 +1,63 @@
+require "date"
+require "ostruct"
+
+module Gplanner
+  class Planner
+    def initialize(type:, day_in_advance: 1)
+      @type = type
+      @day_in_advance = day_in_advance
+    end
+
+    def meta
+      OpenStruct.new(type_metadata[type.to_sym])
+    end
+
+    def self.meta_for(type, options = {})
+      new(type: type, **options).meta
+    end
+
+    private
+
+    attr_reader :type, :day_in_advance
+
+    def type_metadata
+      { day: day_attributes, week: week_attributes, month: month_attributes }
+    end
+
+    def datetime
+      @datetime ||= DateTime.now + day_in_advance
+    end
+
+    def format_date(type_format)
+      datetime.strftime(type_format).downcase
+    end
+
+    def build_filename(filetype, format)
+      [filetype, format_date(format) + ".md"].join("/")
+    end
+
+    def day_attributes
+      {
+        branch: format_date("%Y%m%d-%A"),
+        filename: build_filename("daily", "%Y%m%d-%A"),
+        message: "Add daily plans for #{format_date('%B %d, %Y')}",
+      }
+    end
+
+    def week_attributes
+      {
+        branch: format_date("%Y%m%d-week-%V"),
+        filename: build_filename("weekly", "%Y%m%d-week-%V"),
+        message: "Add weekly plans for week #{format_date('%V, %Y')}",
+      }
+    end
+
+    def month_attributes
+      {
+        branch: format_date("%Y%m%d-%B"),
+        filename: build_filename("monthly", "%Y%m%d-%B"),
+        message: "Add monthly plans for #{format_date('%B, %Y')}",
+      }
+    end
+  end
+end

--- a/spec/acceptance/plan_spec.rb
+++ b/spec/acceptance/plan_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe "Planning" do
+  describe "plan" do
+    it "creates a blank slate for planning" do
+      allow(Gplanner).to receive(:command_line)
+      allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 24))
+
+      command = %w(plan -t day -e)
+      Gplanner.run(command)
+
+      expected_to_run_command("vim daily/20171225-monday.md")
+      expected_to_run_command("touch daily/20171225-monday.md")
+      expected_to_run_command("git checkout -b 20171225-monday")
+    end
+  end
+
+  def expected_to_run_command(command)
+    expect(Gplanner).to have_received(:command_line).with(command)
+  end
+end

--- a/spec/gplanner/planner_spec.rb
+++ b/spec/gplanner/planner_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe Gplanner::Planner do
+  describe ".meta_for" do
+    context "day as an argument" do
+      it "returns day planning attributes" do
+        stub_current_date_to(DateTime.new(2017, 12, 24))
+
+        meta = Gplanner::Planner.meta_for("day", day_in_advance: 1)
+
+        expect(meta.branch).to eq("20171225-monday")
+        expect(meta.filename).to eq("daily/20171225-monday.md")
+        expect(meta.message).to eq("Add daily plans for december 25, 2017")
+      end
+    end
+
+    context "week as an argument" do
+      it "returns week planning attributes" do
+        stub_current_date_to(DateTime.new(2017, 12, 24))
+
+        meta = Gplanner::Planner.meta_for("week")
+
+        expect(meta.branch).to eq("20171225-week-52")
+        expect(meta.filename).to eq("weekly/20171225-week-52.md")
+        expect(meta.message).to eq("Add weekly plans for week 52, 2017")
+      end
+    end
+
+    context "month as an argument" do
+      it "returns month planning attributes" do
+        stub_current_date_to(DateTime.new(2017, 12, 24))
+
+        meta = Gplanner::Planner.meta_for("month")
+
+        expect(meta.branch).to eq("20171225-december")
+        expect(meta.filename).to eq("monthly/20171225-december.md")
+        expect(meta.message).to eq("Add monthly plans for december, 2017")
+      end
+    end
+  end
+
+  def stub_current_date_to(expected_date)
+    allow(DateTime).to receive(:now).and_return(expected_date)
+  end
+end


### PR DESCRIPTION
This commit adds an interface called `plan`, this takes `-t` as type and then it creates the git branch and also file in proper directory it also allows us to pass an `--editor` option, which will also open the file in the vim editor.