### PR TITLE
Add interface to build commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ bundle install
 ### Start planning
 
 ```sh
-bin/planner plan --type day --editor
+bin/planner plan day --editor
+```
+
+### Build commit message
+
+```sh
+bin/planner commit day
 ```
 
 ## License

--- a/lib/gplanner/command.rb
+++ b/lib/gplanner/command.rb
@@ -1,17 +1,22 @@
 module Gplanner
   class Command < Thor
     desc "plan", "Plan your day, week and month"
-    option :type, aliases: "-t", required: true, desc: "Type for the plan"
     option :editor, type: :boolean, aliases: "-e", desc: "Open file in Vim"
 
-    def plan
-      meta = Planner.meta_for(options[:type])
+    def plan(plan_type = "day")
+      meta = Planner.meta_for(plan_type)
       execute_command "git checkout -b #{meta.branch}"
       execute_command "touch #{meta.filename}"
 
       if options[:editor]
         execute_command "vim #{meta.filename}"
       end
+    end
+
+    desc "commit", "Build commit message for types"
+
+    def commit(plan_type = "day")
+      say(Planner.meta_for(plan_type).message)
     end
 
     private

--- a/spec/acceptance/commit_spec.rb
+++ b/spec/acceptance/commit_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe "Commit message" do
+  describe "commit" do
+    it "builds commit messages for the type" do
+      command = %w(commit day)
+      allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 24))
+
+      output = capture_stdout { Gplanner.run(command) }
+
+      expect(output).to match(/Add daily plans for december 25, 2017/)
+    end
+  end
+end

--- a/spec/acceptance/plan_spec.rb
+++ b/spec/acceptance/plan_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe "Planning" do
       allow(Gplanner).to receive(:command_line)
       allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 24))
 
-      command = %w(plan -t day -e)
+      command = %w(plan day --editor)
       Gplanner.run(command)
 
       expected_to_run_command("vim daily/20171225-monday.md")
-      expected_to_run_command("touch daily/20171225-monday.md")
       expected_to_run_command("git checkout -b 20171225-monday")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,12 @@
 require "bundler/setup"
 require "gplanner"
 
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include Gplanner::ConsoleHelper
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,0 +1,29 @@
+module Gplanner
+  module ConsoleHelper
+    def capture_stdout(&_block)
+      original_stdout = $stdout
+      $stdout = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stdout = original_stdout
+      end
+
+      fake.string
+    end
+
+    def capture_stderr(&_block)
+      original_stderr = $stderr
+      $stderr = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stderr = original_stderr
+      end
+
+      fake.string
+    end
+  end
+end


### PR DESCRIPTION
For the planner we need to build lots of commit messages, but this commit adds an interface to make that job easier. Now we only need to call the commit interface and it will build the message for a day, but we can easily change that using  `week` or `month` as a parameters.