### PR TITLE
Set the defaults date to the current one

### DIFF
--- a/lib/gplanner/planner.rb
+++ b/lib/gplanner/planner.rb
@@ -3,7 +3,7 @@ require "ostruct"
 
 module Gplanner
   class Planner
-    def initialize(type:, day_in_advance: 1)
+    def initialize(type:, day_in_advance: 0)
       @type = type
       @day_in_advance = day_in_advance
     end

--- a/lib/gplanner/version.rb
+++ b/lib/gplanner/version.rb
@@ -1,3 +1,3 @@
 module Gplanner
-  VERSION = "0.2.0".freeze
+  VERSION = "0.3.0".freeze
 end

--- a/spec/acceptance/commit_spec.rb
+++ b/spec/acceptance/commit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Commit message" do
   describe "commit" do
     it "builds commit messages for the type" do
       command = %w(commit day)
-      allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 24))
+      allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 25))
 
       output = capture_stdout { Gplanner.run(command) }
 

--- a/spec/acceptance/plan_spec.rb
+++ b/spec/acceptance/plan_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Planning" do
   describe "plan" do
     it "creates a blank slate for planning" do
       allow(Gplanner).to receive(:command_line)
-      allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 24))
+      allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 12, 25))
 
       command = %w(plan day --editor)
       Gplanner.run(command)

--- a/spec/gplanner/planner_spec.rb
+++ b/spec/gplanner/planner_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Gplanner::Planner do
 
     context "week as an argument" do
       it "returns week planning attributes" do
-        stub_current_date_to(DateTime.new(2017, 12, 24))
+        stub_current_date_to(DateTime.new(2017, 12, 25))
 
         meta = Gplanner::Planner.meta_for("week")
 
@@ -28,7 +28,7 @@ RSpec.describe Gplanner::Planner do
 
     context "month as an argument" do
       it "returns month planning attributes" do
-        stub_current_date_to(DateTime.new(2017, 12, 24))
+        stub_current_date_to(DateTime.new(2017, 12, 25))
 
         meta = Gplanner::Planner.meta_for("month")
 


### PR DESCRIPTION
Currently, the planner has a `+1` day mechanism for planning, but sometime it might not work the way we expect, as sometime it might be a minute late on the planning or something and that will need lots of manual work, so this commit sets the default to current time for now, and later we will add CLI option support.